### PR TITLE
feat: support utf-8 output when executing remote command

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -133,7 +133,7 @@ Style/SymbolArray:
   EnforcedStyle: brackets
 
 Metrics/ClassLength:
-  Max: 250
+  Max: 300
 
 Metrics/ParameterLists:
   Max: 15

--- a/app/services/deployer.rb
+++ b/app/services/deployer.rb
@@ -231,8 +231,15 @@ class Deployer
   def run_command_with_log(cmd)
     IO.popen(cmd) do |result|
       while output = result.gets
+        # change encoding so we can display UTF-8 text
+        output.force_encoding("UTF-8")
         # remove color code for logging
-        log ">> #{output.gsub(/\e\[.*?m/, '')}"
+        begin
+          log ">> #{output.gsub(/\e\[.*?m/, '')}"
+        rescue
+          # if some how we still cannot process the log, just ignore it
+          log ">> (Unknown output format)"
+        end
       end
     end
   end

--- a/app/services/deployer.rb
+++ b/app/services/deployer.rb
@@ -232,13 +232,13 @@ class Deployer
     IO.popen(cmd) do |result|
       while output = result.gets
         # change encoding so we can display UTF-8 text
-        output.force_encoding("UTF-8")
+        output.force_encoding('UTF-8')
         # remove color code for logging
         begin
           log ">> #{output.gsub(/\e\[.*?m/, '')}"
         rescue
           # if some how we still cannot process the log, just ignore it
-          log ">> (Unknown output format)"
+          log '>> (Unknown output format)'
         end
       end
     end


### PR DESCRIPTION
this can prevent error when remote command outputs UTF8 text